### PR TITLE
Fix busy-spin loops causing test_io_enable_disable flakiness

### DIFF
--- a/alfalfa_worker/jobs/step_run_process.py
+++ b/alfalfa_worker/jobs/step_run_process.py
@@ -121,12 +121,7 @@ class StepRunProcess(StepRunBase):
             if desired_event_set:
                 event.wait(1)
             else:
-                # Event proxies only expose a "wait until set" primitive, so there is no
-                # equivalent blocking wait for the event to be cleared. Without a short
-                # sleep here this becomes a tight busy-loop that pegs a full CPU core for
-                # the entire duration of every advance() call, starving the simulation
-                # subprocess of CPU time (particularly under CI/container CPU limits) and
-                # making it more likely to overrun advance_timeout.
+                # avoid busy-spinning at 100% CPU while waiting for the event to clear
                 sleep(0.05)
         if self.error_event.is_set():
             self.handle_process_error()

--- a/alfalfa_worker/jobs/step_run_process.py
+++ b/alfalfa_worker/jobs/step_run_process.py
@@ -2,7 +2,7 @@ import threading
 from ctypes import c_wchar_p
 from datetime import datetime
 from multiprocessing import Manager, Process
-from time import time
+from time import sleep, time
 
 from alfalfa_worker.jobs.step_run_base import StepRunBase
 from alfalfa_worker.lib.constants import DATETIME_FORMAT
@@ -120,6 +120,14 @@ class StepRunProcess(StepRunBase):
             self.check_for_errors()
             if desired_event_set:
                 event.wait(1)
+            else:
+                # Event proxies only expose a "wait until set" primitive, so there is no
+                # equivalent blocking wait for the event to be cleared. Without a short
+                # sleep here this becomes a tight busy-loop that pegs a full CPU core for
+                # the entire duration of every advance() call, starving the simulation
+                # subprocess of CPU time (particularly under CI/container CPU limits) and
+                # making it more likely to overrun advance_timeout.
+                sleep(0.05)
         if self.error_event.is_set():
             self.handle_process_error()
         if not self.simulation_process.is_alive():
@@ -146,7 +154,8 @@ class StepRunProcess(StepRunBase):
             while (self.simulation_process.is_alive()
                    and time() - stop_start_time < self.options.stop_timeout
                    and not self.error_event.is_set()):
-                pass
+                # See the comment in _wait_for_event: avoid busy-spinning at 100% CPU.
+                sleep(0.05)
             if time() - stop_start_time > self.options.stop_timeout and self.simulation_process.is_alive():
                 self.simulation_process.kill()
                 raise JobExceptionExternalProcess("Simulation process stopped responding and was killed.")

--- a/alfalfa_worker/lib/job.py
+++ b/alfalfa_worker/lib/job.py
@@ -200,11 +200,7 @@ class Job(metaclass=JobMetaclass):
 
     @with_run()
     def _check_messages(self) -> None:
-        # Use a blocking read with a short timeout instead of the non-blocking default
-        # (timeout=0). The non-blocking form turns start_message_loop into a tight
-        # busy-loop that repeatedly hset()s the job status to redis as fast as possible,
-        # burning a full CPU core and hammering redis while a job is simply waiting for
-        # its next message (e.g. between advance() calls).
+        # Blocking read avoids busy-spinning at 100% CPU while idle (default timeout=0 is non-blocking)
         message = self.redis_pubsub.get_message(timeout=1.0)
         try:
             if message and message['data'].__class__ == bytes:

--- a/alfalfa_worker/lib/job.py
+++ b/alfalfa_worker/lib/job.py
@@ -200,7 +200,12 @@ class Job(metaclass=JobMetaclass):
 
     @with_run()
     def _check_messages(self) -> None:
-        message = self.redis_pubsub.get_message()
+        # Use a blocking read with a short timeout instead of the non-blocking default
+        # (timeout=0). The non-blocking form turns start_message_loop into a tight
+        # busy-loop that repeatedly hset()s the job status to redis as fast as possible,
+        # burning a full CPU core and hammering redis while a job is simply waiting for
+        # its next message (e.g. between advance() calls).
+        message = self.redis_pubsub.get_message(timeout=1.0)
         try:
             if message and message['data'].__class__ == bytes:
                 self.logger.info(f"received message: {message}")

--- a/tests/worker/lib/mock_redis_pub_sub.py
+++ b/tests/worker/lib/mock_redis_pub_sub.py
@@ -7,10 +7,13 @@ class MockRedisPubSub():
         self.messages: SimpleQueue = SimpleQueue()
         self.channels = []
 
-    def get_message(self):
+    def get_message(self, timeout=0.0):
         message = None
         try:
-            message = self.messages.get(False)
+            # Mirror redis-py's PubSub.get_message: timeout=0.0 (or None, which SimpleQueue
+            # treats as block-forever) polls without blocking indefinitely, while a positive
+            # timeout blocks up to that many seconds waiting for a message.
+            message = self.messages.get(block=bool(timeout), timeout=timeout or None)
             return message
         except Empty:
             return message

--- a/tests/worker/lib/mock_redis_pub_sub.py
+++ b/tests/worker/lib/mock_redis_pub_sub.py
@@ -10,9 +10,7 @@ class MockRedisPubSub():
     def get_message(self, timeout=0.0):
         message = None
         try:
-            # Mirror redis-py's PubSub.get_message: timeout=0.0 (or None, which SimpleQueue
-            # treats as block-forever) polls without blocking indefinitely, while a positive
-            # timeout blocks up to that many seconds waiting for a message.
+            # Mirrors redis-py's PubSub.get_message signature/behavior
             message = self.messages.get(block=bool(timeout), timeout=timeout or None)
             return message
         except Empty:


### PR DESCRIPTION
## Summary

Split out from #633, where the underlying flaky-test investigation happened.

`tests/integration/test_small_office_osw.py::test_io_enable_disable` has been intermittently failing in CI with a wrong output value (e.g. asserting `Python Output == 20` but getting `21.735...`), unrelated to any change in that PR. Root-caused this to two busy-spin (tight, unslept `while` loops) bugs in the worker's job/simulation synchronization code:

- **`StepRunProcess._wait_for_event`** (used by `advance()`) and **`StepRunProcess.stop()`** wait on `multiprocessing.Manager` `Event` proxies for the event to be *cleared*, but the loop had no sleep in that branch — it busy-spins at ~100% CPU for the entire duration of every `advance()`/`stop()` call.
- **`Job._check_messages`** called `redis_pubsub.get_message()` with the default non-blocking `timeout=0`, so `start_message_loop` spins as fast as possible while idle, `hset()`-ing the job status to redis on every iteration.

Under CPU contention (constrained CI runners, `--scale worker=2` running two of these loops concurrently) this starves the EnergyPlus simulation subprocess of CPU time, making it more likely to overrun `advance_timeout` and abort/corrupt the run mid-step — producing stale or incorrect point values on the next read. This is the most likely explanation for the intermittent failure.

## Changes

- `alfalfa_worker/jobs/step_run_process.py`: add a short `sleep(0.05)` in both busy-spin loops.
- `alfalfa_worker/lib/job.py`: use a 1s blocking `get_message(timeout=1.0)` read instead of a non-blocking poll.
- `tests/worker/lib/mock_redis_pub_sub.py`: update the test double to accept the new `timeout` argument (mirrors redis-py's `PubSub.get_message` semantics).

## Testing

- Full unit test suite passes locally (`poetry run pytest`): 30 passed.
- Ran `test_io_enable_disable` repeatedly, including with worker containers CPU-limited via `docker update --cpus=1.0` (the scenario most likely to trigger the original race) — passed consistently after the fix.
- `pre-commit run` passes on all changed files.

Note: I was not able to 100% deterministically reproduce the original race locally even before this fix (it's rare), so this can't be proven to fully eliminate the flakiness — but the busy-spin loops are a real, independently-justified defect (CPU/redis thrashing) and a strong contributing factor given the failure's timing-sensitive nature.
