### PR TITLE
Restrict Dependabot pip/npm updates to direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
     groups:
       python-dependencies:
         patterns:
@@ -17,6 +19,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- Adds `allow: - dependency-type: "direct"` to the `pip` and `npm` ecosystem entries in `.github/dependabot.yml`.
- This limits Dependabot version-update PRs to direct dependencies only, skipping transitive/indirect dependency bumps.
- Docker and GitHub Actions ecosystems are left unchanged since those ecosystems only ever track direct dependencies (no transitive concept).

## Why
Reduces noise from Dependabot opening PRs for indirect/transitive dependency bumps that are not directly declared in pyproject.toml/package.json.
